### PR TITLE
Habilita o cop RSpec/LetSetup

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -26,3 +26,6 @@ RSpec/DescribeClass:
 RSpec/MultipleMemoizedHelpers:
   Max: 7
   AllowSubject: true
+
+RSpec/LetSetup:
+  Enabled: true


### PR DESCRIPTION
Dado a spec abaixo:

```ruby
let!(:cart) { create(:ready_to_pay_cart) }
let!(:other_cart) { create(:cart) }

it "does something" do
  expect(Cart.ready_to_pay_carts).to eq([cart])
end
```

Rodando o rubocop vai retornar:

```
Inspecting 1 file
C

Offenses:

spec/carts_spec.rb:7:3: C: RSpec/LetSetup: Do not use let! to setup objects not referenced in tests.
  let!(:other_cart) { create(:cart) }
  ^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

Para corrigir, basta usar um `before`

```ruby
let!(:cart) { create(:ready_to_pay_cart) }

before { create(:cart) }

it "does something" do
  expect(Cart.ready_to_pay_carts).to eq([cart])
end
```