### PR TITLE
Habilita o cop Style/FrozenStringLiteralComment

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -32,3 +32,7 @@ RSpec/LetSetup:
 
 Layout/LineLength:
   Max: 120
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always_true


### PR DESCRIPTION
Força o uso do magic comment `# frozen_string_literal: true` em todos os arquivos