### PR TITLE
Habilita o cop Layout/EmptyLineAfterGuardClause

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -33,6 +33,9 @@ RSpec/LetSetup:
 Layout/LineLength:
   Max: 120
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true


### PR DESCRIPTION
A ideia é ter uma linha em branco depois de todos os `return`s de um método

```
return 1 if a
return 2 if b

3
```

ao invés de:

```
return 1 if a
return 2 if b
3
```